### PR TITLE
Update to v3.6.3-1

### DIFF
--- a/org.jupyter.JupyterLab.metainfo.xml
+++ b/org.jupyter.JupyterLab.metainfo.xml
@@ -19,6 +19,7 @@
   <url type="bugtracker">https://github.com/jupyterlab/jupyterlab-desktop/issues</url>
   <content_rating type="oars-1.1"></content_rating>
   <releases>
+    <release version="3.6.3-1" date="2023-04-23" />
     <release version="3.6.2-1" date="2023-03-23" />
     <release version="3.6.1-2" date="2023-02-24" />
   </releases>

--- a/org.jupyter.JupyterLab.yaml
+++ b/org.jupyter.JupyterLab.yaml
@@ -40,8 +40,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-Debian.deb
-        sha256: 7f4444d3e258c8f0b76be83cb4a074ff7ed238ce265a92a1d734b44d040e96e1
+        url: https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.6.3-1/JupyterLab-Setup-Debian.deb
+        sha256: dd7b88dde09121b2e6895039146ff723d15b81c66ef6f6b75cd2f2079d7bc018
         x-checker-data:
           type: git
           tag-pattern: ^v\d+(\.\d+)*(-\d+)?$


### PR DESCRIPTION
v3.6.3-1 is available now: https://github.com/jupyterlab/jupyterlab-desktop/releases

This PR updates the content of the flatpak to the most recent version of jupyterlab-desktop.