### PR TITLE
Remove filesystem=home permission

### DIFF
--- a/org.jupyter.JupyterLab.yaml
+++ b/org.jupyter.JupyterLab.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=home
 rename-desktop-file: jupyterlab-desktop.desktop
 rename-icon: jupyterlab-desktop
 modules:


### PR DESCRIPTION
Disabling home access allows me to use the single click install for the built in python environment, I don't know exactly why this works. 

JupyterLab seems to use portal compatible file chooser so it shouldn't cause too much of an issue.

It might be a good idea to set the "Default working directory" to something like `$XDG_DOCUMENTS_DIR/JupyterLab` and give access with `--filesystem=xdg-documents/JupyterLab:create`. I don't have enough insight into JupyterLabs inner workings to figure this out at the moment.

(getting [`$XDG_DOCUMENTS_DIR`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/))

Fixes #2